### PR TITLE
Add `disconnect()` method for resetting the connection pool

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,11 @@ Accessing redis-py's Sentinel instance
 Change log
 ----------
 
+v2.1.0
+~~~~~~
+
+* Added `disconnect()` method for resetting the connection pool
+
 v2.0.1
 ~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
 setup(
     name='Flask-Redis-Sentinel',
     py_modules=['flask_redis_sentinel'],
-    version='2.0.1',
+    version='2.1.0',
     install_requires=['Flask>=0.10.1', 'redis>=2.10.3', 'redis_sentinel_url>=1.0.0,<2.0.0', 'six'],
     description='Redis-Sentinel integration for Flask',
     long_description=read('README.rst'),


### PR DESCRIPTION
I need this for unit tests that run things in many different threads.