### PR TITLE
Bug fix when use customize client class will not be able to pass the …

### DIFF
--- a/flask_redis_sentinel.py
+++ b/flask_redis_sentinel.py
@@ -156,6 +156,8 @@ class RedisSentinel(object):
     @staticmethod
     def _config_from_variables(config, the_class):
         args = inspect.getargspec(the_class.__init__).args
+        base_args = inspect.getargspec(redis.client.Redis.__init__).args
+        args.extend(base_args)
         args.remove('self')
         args.remove('host')
         args.remove('port')


### PR DESCRIPTION
When use rejson.client which init function does not have the basic Redis client parameter. It _confg_from_variables function would break the config parameter transfer. So need to inspect the original Redis init parameter args for extend.

For example its init function is below:
    def __init__(self, encoder=None, decoder=None, *args, **kwargs):
        .......